### PR TITLE
Updated SDL_GetError calls

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -13,14 +13,14 @@ end
 function load_font(font_path::String, font_size::Int)
     # Initialize the TTF library
     if TTF_Init() == -1
-        error("Failed to initialize SDL_ttf: ", SDL_GetError)
+        error("Failed to initialize SDL_ttf: $(unsafe_string(SDL_GetError()))")
     end
 
     # Load the font
     font = TTF_OpenFont(font_path, font_size)
     
     if font == C_NULL
-        error("Failed to load font: ", SDL_GetError())
+        error("Failed to load font: $(unsafe_string(SDL_GetError()))")
     end
 
     return font


### PR DESCRIPTION
Wrapped the other two SDL_GetError calls with unsafe_string, as they won't give you a proper error message without that. Screenshot with a non-existent font path:
![image](https://github.com/user-attachments/assets/cfd1ef53-3071-44fa-9b4b-5f32405a3dc3)
 